### PR TITLE
Prevent setting `X-Flow-Identifier` to `nil`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ Basic usage without any parameters yielding default json encoded jsend format in
 
 ```ruby
 Jsender::Rack.success
- => [200, {"Content-Type"=>"application/json", "X-Flow-Identifier"=>nil}, "{\"status\":\"success\",\"data\":null}"]
+ => [200, {"Content-Type"=>"application/json"}, "{\"status\":\"success\",\"data\":null}"]
 
 Jsender::Rack.failure
- => [400, {"Content-Type"=>"application/json", "X-Flow-Identifier"=>nil}, "{\"status\":\"fail\",\"data\":{\"message\":\"A failure has occurred\"}}"]
+ => [400, {"Content-Type"=>"application/json"}, "{\"status\":\"fail\",\"data\":{\"message\":\"A failure has occurred\"}}"]
 
 Jsender::Rack.error
-=> [500, {"Content-Type"=>"application/json", "X-Flow-Identifier"=>nil}, "{\"status\":\"error\",\"message\":\"An error has occurred\"}"]
+=> [500, {"Content-Type"=>"application/json"}, "{\"status\":\"error\",\"message\":\"An error has occurred\"}"]
 ```
 
 Or with parameters yielding the correct json encoded jsend format in a Rack tuple for use in controllers (including Sinatra):
@@ -79,10 +79,10 @@ Or with parameters yielding the correct json encoded jsend format in a Rack tupl
 Jsender::Rack.success(data: {'key' => 'value'}, code: 201, flow_id: '123')
  => [201, {"Content-Type"=>"application/json", "X-Flow-Identifier"=>"123"}, "{\"status\":\"success\",\"data\":{\"key\":\"value\"}}"]
 
- Jsender::Rack.failure(message: 'some custom failure message', code: 201, flow_id: '123')
+Jsender::Rack.failure(message: 'some custom failure message', code: 201, flow_id: '123')
  => [201, {"Content-Type"=>"application/json", "X-Flow-Identifier"=>"123"}, "{\"status\":\"fail\",\"data\":{\"message\":\"some custom failure message\"}}"]
 
- Jsender::Rack.error(message: 'some custom failure message', code: 201, flow_id: '123')
+Jsender::Rack.error(message: 'some custom failure message', code: 201, flow_id: '123')
  => [201, {"Content-Type"=>"application/json", "X-Flow-Identifier"=>"123"}, "{\"status\":\"error\",\"message\":\"some custom failure message\"}"]
 ```
 
@@ -92,7 +92,7 @@ Rack middlware responses require that the body of the response tuple is in an ar
 
 ```ruby
 Jsender::Rack.error(body_as_array: true)
- => [500, {"Content-Type"=>"application/json", "X-Flow-Identifier"=>nil}, ["{\"status\":\"error\",\"message\":\"An error has occurred\"}"]]
+ => [500, {"Content-Type"=>"application/json"}, ["{\"status\":\"error\",\"message\":\"An error has occurred\"}"]]
 ```
 
 ## Development

--- a/lib/jsender/rack.rb
+++ b/lib/jsender/rack.rb
@@ -34,10 +34,13 @@ module Jsender
     end
 
     def headers(flow_id:)
-      {
-        'Content-Type' => 'application/json',
-        'X-Flow-Identifier' => flow_id
+      headers = {
+        'Content-Type' => 'application/json'
       }
+
+      headers.merge!('X-Flow-Identifier' => flow_id) if flow_id
+
+      headers
     end
   end
 

--- a/lib/jsender/version.rb
+++ b/lib/jsender/version.rb
@@ -1,3 +1,3 @@
 module Jsender
-  VERSION = "2.1.1"
+  VERSION = "2.2.0"
 end

--- a/spec/jsender_rack_spec.rb
+++ b/spec/jsender_rack_spec.rb
@@ -30,8 +30,7 @@ describe Jsender::Rack do
         [
           200,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           {
             'status' => 'success',
@@ -48,8 +47,7 @@ describe Jsender::Rack do
         [
           200,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           {
             'status' => 'success',
@@ -84,8 +82,7 @@ describe Jsender::Rack do
         [
           code,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           {
             'status' => 'success',
@@ -102,8 +99,7 @@ describe Jsender::Rack do
         [
           200,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           [
             {
@@ -124,8 +120,7 @@ describe Jsender::Rack do
         [
           400,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           {
             'status' => 'fail',
@@ -144,8 +139,7 @@ describe Jsender::Rack do
         [
           400,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           {
             'status' => 'fail',
@@ -164,8 +158,7 @@ describe Jsender::Rack do
         [
           400,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           {
             'status' => 'fail',
@@ -202,8 +195,7 @@ describe Jsender::Rack do
         [
           code,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           {
             'status' => 'fail',
@@ -222,8 +214,7 @@ describe Jsender::Rack do
         [
           400,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           [
             {
@@ -246,8 +237,7 @@ describe Jsender::Rack do
         [
           500,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           {
             'status' => 'error',
@@ -264,8 +254,7 @@ describe Jsender::Rack do
         [
           500,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           {
             'status' => 'error',
@@ -300,8 +289,7 @@ describe Jsender::Rack do
         [
           code,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           {
             'status' => 'error',
@@ -318,8 +306,7 @@ describe Jsender::Rack do
         [
           500,
           {
-            "Content-Type"      => "application/json",
-            "X-Flow-Identifier" => nil
+            "Content-Type" => "application/json"
           },
           [
             {


### PR DESCRIPTION
When running an rack application in "development" environment,
setting `X-Flow-Identifier` to `nil` causes failure:

```bash
Rack::Lint::LintError: a header value must be a String, but the value of 'X-Flow-Identifier' is a NilClass
  /usr/local/bundle/gems/rack-2.0.7/lib/rack/lint.rb:20:in `assert'
  /usr/local/bundle/gems/rack-2.0.7/lib/rack/lint.rb:645:in `block in check_headers'
```

This comes from [`Rack::Lint`](https://github.com/rack/rack/blob/c8d0f2bb35d0abaab3a02fe7eec41bb2d9e68ddf/lib/rack/lint.rb)
middleware that is used by default on "development" environment,
see https://github.com/rack/rack/blob/master/lib/rack/server.rb#L269-L276.

`Rack::Lint` middleware validates an application and the requests and
responses according to the [Rack spec](https://github.com/rack/rack/blob/c8d0f2bb35d0abaab3a02fe7eec41bb2d9e68ddf/SPEC).
Acording to the spec a header value must be a String,
see https://github.com/rack/rack/blob/c8d0f2bb35d0abaab3a02fe7eec41bb2d9e68ddf/lib/rack/lint.rb#L646-L647.